### PR TITLE
Fix child_process spawn on Windows

### DIFF
--- a/src/actions/build.js
+++ b/src/actions/build.js
@@ -63,7 +63,10 @@ module.exports = async function build({basePath, flags}) {
 }
 
 function spawn(cmd, args, options) {
+  // ref: https://stackoverflow.com/questions/37459717/error-spawn-enoent-on-windows/37487465
+  const withShellOptions = process.platform === 'win32' ? {...options, ...{shell: true}} : options
+
   return new Promise((resolve, reject) => {
-    childProcess.spawn(cmd, args, options).on('error', reject).on('close', resolve)
+    childProcess.spawn(cmd, args, withShellOptions).on('error', reject).on('close', resolve)
   })
 }

--- a/src/actions/build.js
+++ b/src/actions/build.js
@@ -64,7 +64,7 @@ module.exports = async function build({basePath, flags}) {
 
 function spawn(cmd, args, options) {
   // ref: https://stackoverflow.com/questions/37459717/error-spawn-enoent-on-windows/37487465
-  const withShellOptions = process.platform === 'win32' ? {...options, ...{shell: true}} : options
+  const withShellOptions = process.platform === 'win32' ? {...options, shell: true} : options
 
   return new Promise((resolve, reject) => {
     childProcess.spawn(cmd, args, withShellOptions).on('error', reject).on('close', resolve)


### PR DESCRIPTION
According to [NodeJS doc](https://nodejs.org/dist/latest-v10.x/docs/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows), `{ shell: true }` must be specified to run `spawn` with shell.

The proposed fix optionally adds the mentioned property when detected running on Windows. See below result.

![image](https://user-images.githubusercontent.com/977413/123068044-1e879a00-d444-11eb-96d4-f821dc7f5b0e.png)

PS: I could also update fix and use [cross-spawn](https://www.npmjs.com/package/cross-spawn) if you prefer.
